### PR TITLE
Include labours script and its dependencies as optdeps

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,13 +7,27 @@ pkgname=hercules-analysis-git
 pkgver=10.7.2.r4.g13a2081
 pkgrel=1
 depends=('go' 'protobuf')
-makedepends=('make' 'git')
+makedepends=('make' 'git' 'python-setuptools')
 pkgdesc='Gaining advanced insights from Git repository history.'
 arch=('any')
 license=('Apache')
 source=('git+https://github.com/src-d/hercules.git')
 sha256sums=('SKIP')
 url='https://github.com/src-d/hercules'
+optdepends=(
+    'python-matplotlib: to use the labours python script'
+    'python-scipy: to use the labours python script'
+    'python-pandas: to use the labours python script'
+    'python-yaml: to use the labours python script'
+    'python-protobuf: to use the labours python script'
+    'python-munch: to use the labours python script'
+    'python-hdbscan: to use the labours python script'
+    'python-seriate: to use the labours python script'
+    'python-fastdtw: to use the labours python script'
+    'python-dateutil: to use the labours python script'
+    'python-lifelines: to use the labours python script'
+    'python-tqdm: to use the labours python script'
+)
 
 pkgver() {
   cd "${srcdir}/hercules"
@@ -23,9 +37,13 @@ pkgver() {
 build() {
   cd "${srcdir}/hercules"
   make
+  cd "${srcdir}/hercules/python"
+  python setup.py build
 }
 
 package() {
   cd "${srcdir}/hercules"
   install -Dm755 hercules "${pkgdir}/usr/bin/hercules"
+  cd "${srcdir}/hercules/python"
+  python setup.py install --root="$pkgdir/" --prefix=/usr --optimize=1 --skip-build
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,10 @@
 pkgname=hercules-analysis-git
 pkgver=10.7.2.r4.g13a2081
 pkgrel=1
-depends=('go' 'protobuf')
+depends=('go' 'protobuf'
+  'python-matplotlib' 'python-scipy' 'python-pandas' 'python-yaml' 'python-protobuf'
+  'python-munch' 'python-hdbscan' 'python-seriate' 'python-fastdtw' 'python-dateutil'
+  'python-lifelines' 'python-tqdm')
 makedepends=('make' 'git' 'python-setuptools')
 pkgdesc='Gaining advanced insights from Git repository history.'
 arch=('any')
@@ -14,20 +17,6 @@ license=('Apache')
 source=('git+https://github.com/src-d/hercules.git')
 sha256sums=('SKIP')
 url='https://github.com/src-d/hercules'
-optdepends=(
-    'python-matplotlib: to use the labours python script'
-    'python-scipy: to use the labours python script'
-    'python-pandas: to use the labours python script'
-    'python-yaml: to use the labours python script'
-    'python-protobuf: to use the labours python script'
-    'python-munch: to use the labours python script'
-    'python-hdbscan: to use the labours python script'
-    'python-seriate: to use the labours python script'
-    'python-fastdtw: to use the labours python script'
-    'python-dateutil: to use the labours python script'
-    'python-lifelines: to use the labours python script'
-    'python-tqdm: to use the labours python script'
-)
 
 pkgver() {
   cd "${srcdir}/hercules"


### PR DESCRIPTION
Hi there!

I installed hercules from the AUR and then realised it didn't come with labours, so I figured I'd put together some edits so that it could come bundled. If you think that's a good idea then I think these changes should do it. If you think that it makes more sense for hercules and labours to be packaged separately, then I can instead create a PKGBUILD for labours only. The labours dependencies are added as optional as it won't pull in a bunch of other packages if a user doesn't want to use labours.

In either case, `python-seriate` is the only dependency that isn't available in the arch repos or AUR so I will have to make a PKGBUILD for that. For labours to run after it's been installed. (I haven't got too deep into uses these yet so I don't know what exactly would fail without this dep).

What do you think?